### PR TITLE
Remove SSH private key references

### DIFF
--- a/examples/private-cluster-cl/README.md
+++ b/examples/private-cluster-cl/README.md
@@ -25,7 +25,7 @@ You can add the `os_tenant_id` in `terraform.tfvars` or source your `openrc` cre
 $ ssh-keygen -f terraform_ssh_key -q -N ""
 ```
 
-If you generate a new keypair, put its path in `terraform.tfvars` undar variables `private_sshkey` and `public_sshkey`.
+If you generate a new keypair, put its path in `terraform.tfvars` under variable `public_sshkey`.
 
 ## Run it
 

--- a/examples/private-cluster-cl/main.tf
+++ b/examples/private-cluster-cl/main.tf
@@ -57,8 +57,6 @@ module "etcd" {
   post_install_modules    = true
   cfssl                   = true
   ssh_user                = "core"
-  ssh_private_key         = "${file(var.private_sshkey)}"
-  ssh_bastion_private_key = "${file("${var.private_sshkey}")}"
   ssh_bastion_host        = "${module.network.bastion_public_ip}"
   ssh_bastion_user        = "core"
 }

--- a/examples/private-cluster-cl/variables.tf
+++ b/examples/private-cluster-cl/variables.tf
@@ -33,11 +33,6 @@ variable "count" {
   default     = 3
 }
 
-variable "private_sshkey" {
-  description = "Key to use to ssh connect"
-  default     = "~/.ssh/id_rsa"
-}
-
 variable "public_sshkey" {
   description = "Key to use to ssh connect"
   default     = "~/.ssh/id_rsa.pub"

--- a/examples/private-cluster/README.md
+++ b/examples/private-cluster/README.md
@@ -25,7 +25,7 @@ You can add the `os_tenant_id` in `terraform.tfvars` or source your `openrc` cre
 $ ssh-keygen -f terraform_ssh_key -q -N ""
 ```
 
-If you generate a new keypair, put its path in `terraform.tfvars` undar variables `private_sshkey` and `public_sshkey`.
+If you generate a new keypair, put its path in `terraform.tfvars` under variable `public_sshkey`.
 
 ## Run it
 

--- a/examples/private-cluster/main.tf
+++ b/examples/private-cluster/main.tf
@@ -57,8 +57,6 @@ module "etcd" {
   post_install_modules    = true
   cfssl                   = true
   ssh_user                = "centos"
-  ssh_private_key         = "${file(var.private_sshkey)}"
-  ssh_bastion_private_key = "${file("${var.private_sshkey}")}"
   ssh_bastion_host        = "${module.network.bastion_public_ip}"
   ssh_bastion_user        = "core"
 }

--- a/examples/private-cluster/variables.tf
+++ b/examples/private-cluster/variables.tf
@@ -33,11 +33,6 @@ variable "count" {
   default     = 3
 }
 
-variable "private_sshkey" {
-  description = "Key to use to ssh connect"
-  default     = "~/.ssh/id_rsa"
-}
-
 variable "public_sshkey" {
   description = "Key to use to ssh connect"
   default     = "~/.ssh/id_rsa.pub"

--- a/examples/public-cluster-cl/README.md
+++ b/examples/public-cluster-cl/README.md
@@ -25,7 +25,7 @@ You can add the `os_tenant_id` in `terraform.tfvars` or source your `openrc` cre
 $ ssh-keygen -f terraform_ssh_key -q -N ""
 ```
 
-If you generate a new keypair, put its path in `terraform.tfvars` undar variables `private_sshkey` and `public_sshkey`.
+If you generate a new keypair, put its path in `terraform.tfvars` under variable `public_sshkey`.
 
 ## Run it
 

--- a/examples/public-cluster-cl/main.tf
+++ b/examples/public-cluster-cl/main.tf
@@ -55,7 +55,6 @@ module "etcd" {
   ignition_mode             = true
   public_security_group_ids = ["${openstack_networking_secgroup_v2.sg.id}"]
   ssh_user                  = "core"
-  ssh_private_key           = "${file(var.private_sshkey)}"
   post_install_modules      = true
   associate_public_ipv4     = true
   associate_private_ipv4    = false

--- a/examples/public-cluster-cl/variables.tf
+++ b/examples/public-cluster-cl/variables.tf
@@ -33,11 +33,6 @@ variable "count" {
   default     = 3
 }
 
-variable "private_sshkey" {
-  description = "Key to use to ssh connect"
-  default     = "~/.ssh/id_rsa"
-}
-
 variable "public_sshkey" {
   description = "Key to use to ssh connect"
   default     = "~/.ssh/id_rsa.pub"

--- a/examples/public-cluster/README.md
+++ b/examples/public-cluster/README.md
@@ -25,7 +25,7 @@ You can add the `os_tenant_id` in `terraform.tfvars` or source your `openrc` cre
 $ ssh-keygen -f terraform_ssh_key -q -N ""
 ```
 
-If you generate a new keypair, put its path in `terraform.tfvars` undar variables `private_sshkey` and `public_sshkey`.
+If you generate a new keypair, put its path in `terraform.tfvars` undar variable `public_sshkey`.
 
 ## Run it
 

--- a/examples/public-cluster/main.tf
+++ b/examples/public-cluster/main.tf
@@ -55,7 +55,6 @@ module "etcd" {
   ignition_mode             = false
   public_security_group_ids = ["${openstack_networking_secgroup_v2.sg.id}"]
   ssh_user                  = "centos"
-  ssh_private_key           = "${file(var.private_sshkey)}"
   post_install_modules      = true
   associate_public_ipv4     = true
   associate_private_ipv4    = false

--- a/examples/public-cluster/variables.tf
+++ b/examples/public-cluster/variables.tf
@@ -33,11 +33,6 @@ variable "count" {
   default     = 3
 }
 
-variable "private_sshkey" {
-  description = "Key to use to ssh connect"
-  default     = "~/.ssh/id_rsa"
-}
-
 variable "public_sshkey" {
   description = "Key to use to ssh connect"
   default     = "~/.ssh/id_rsa.pub"

--- a/main.tf
+++ b/main.tf
@@ -187,10 +187,8 @@ module "post_install_cfssl" {
   triggers                = ["${element(concat(openstack_compute_instance_v2.singlenet_etcd.*.id, openstack_compute_instance_v2.multinet_etcd.*.id), 0)}"]
   ipv4_addrs              = ["${element(concat(openstack_compute_instance_v2.singlenet_etcd.*.access_ip_v4, openstack_compute_instance_v2.multinet_etcd.*.access_ip_v4), 0)}"]
   ssh_user                = "${var.ssh_user}"
-  ssh_private_key         = "${var.ssh_private_key}"
   ssh_bastion_host        = "${var.ssh_bastion_host}"
   ssh_bastion_user        = "${var.ssh_bastion_user}"
-  ssh_bastion_private_key = "${var.ssh_bastion_private_key}"
 }
 
 module "post_install_etcd" {
@@ -199,10 +197,8 @@ module "post_install_etcd" {
   triggers                = ["${concat(openstack_compute_instance_v2.singlenet_etcd.*.id, openstack_compute_instance_v2.multinet_etcd.*.id)}"]
   ipv4_addrs              = ["${concat(openstack_compute_instance_v2.singlenet_etcd.*.access_ip_v4, openstack_compute_instance_v2.multinet_etcd.*.access_ip_v4)}"]
   ssh_user                = "${var.ssh_user}"
-  ssh_private_key         = "${var.ssh_private_key}"
   ssh_bastion_host        = "${var.ssh_bastion_host}"
   ssh_bastion_user        = "${var.ssh_bastion_user}"
-  ssh_bastion_private_key = "${var.ssh_bastion_private_key}"
 }
 
 # This is somekind of a hack to ensure that when instances ids are output and made

--- a/modules/install-etcd/README.md
+++ b/modules/install-etcd/README.md
@@ -86,10 +86,8 @@ module "provision_etcd" {
   triggers                = ["A list of trigger values"]
   ipv4_addrs              = ["192.168.1.200", "..."]
   ssh_user                = "centos"
-  ssh_private_key         = "${file("~/.ssh/id_rsa")}"
   ssh_bastion_host        = "34.234.13.XX"
   ssh_bastion_user        = "core"
-  ssh_bastion_private_key = "${file("~/.ssh/id_rsa")}"
 }
 ```
 

--- a/modules/install-etcd/main.tf
+++ b/modules/install-etcd/main.tf
@@ -8,10 +8,8 @@ resource "null_resource" "post_install_etcd" {
   connection {
     host                = "${element(var.ipv4_addrs, count.index)}"
     user                = "${var.ssh_user}"
-    private_key         = "${var.ssh_private_key}"
     bastion_host        = "${var.ssh_bastion_host}"
     bastion_user        = "${var.ssh_bastion_user}"
-    bastion_private_key = "${var.ssh_bastion_private_key}"
   }
 
   provisioner "remote-exec" {

--- a/modules/install-etcd/variables.tf
+++ b/modules/install-etcd/variables.tf
@@ -23,10 +23,6 @@ variable "install_dir" {
   default     = "/opt/etcd"
 }
 
-variable "ssh_private_key" {
-  description = "The ssh private key used to post provision the etcd cluster. This is required if `post_install_module` is set to `true`. It must be set accordingly to `ssh_key_pair"
-}
-
 variable "ssh_bastion_host" {
   description = "The address of the bastion host used to post provision the etcd cluster. This may be required if `post_install_module` is set to `true`"
   default     = ""
@@ -34,11 +30,6 @@ variable "ssh_bastion_host" {
 
 variable "ssh_bastion_user" {
   description = "The ssh username of the bastion host used to post provision the etcd cluster. This may be required if `post_install_module` is set to `true`"
-  default     = ""
-}
-
-variable "ssh_bastion_private_key" {
-  description = "The ssh private key of the bastion host used to post provision the etcd cluster. This may be required if `post_install_module` is set to `true`"
   default     = ""
 }
 

--- a/test/runtest.sh
+++ b/test/runtest.sh
@@ -23,6 +23,9 @@ test_tf(){
     return $res
 }
 
+if [ ! -f "$SSH_AUTH_SOCK" ]; then
+    eval $(ssh-agent) && ssh-add ${TEST_SSH_PRIVATE_KEY:-$HOME/.ssh/id_rsa}
+fi
 
 # if destroy mode, clean previous terraform setup
 if [ "${CLEAN}" == "1" ]; then

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -3,6 +3,9 @@
 REGIONS=${1:-$OS_REGION_NAME}
 DIRS=(public-cluster public-cluster-cl private-cluster private-cluster-cl)
 
+if [ ! -f "$SSH_AUTH_SOCK" ]; then
+    eval $(ssh-agent) && ssh-add ${TEST_SSH_PRIVATE_KEY:-$HOME/.ssh/id_rsa}
+fi
 
 EXIT=0
 for d in ${DIRS[@]}; do

--- a/variables.tf
+++ b/variables.tf
@@ -108,11 +108,6 @@ variable "ssh_user" {
   default     = "core"
 }
 
-variable "ssh_private_key" {
-  description = "The ssh private key used to post provision the etcd cluster. This is required if `post_install_module` is set to `true`. It must be set accordingly to `ssh_key_pair"
-  default     = ""
-}
-
 variable "ssh_bastion_host" {
   description = "The address of the bastion host used to post provision the etcd cluster. This may be required if `post_install_module` is set to `true`"
   default     = ""
@@ -120,11 +115,6 @@ variable "ssh_bastion_host" {
 
 variable "ssh_bastion_user" {
   description = "The ssh username of the bastion host used to post provision the etcd cluster. This may be required if `post_install_module` is set to `true`"
-  default     = ""
-}
-
-variable "ssh_bastion_private_key" {
-  description = "The ssh private key of the bastion host used to post provision the etcd cluster. This may be required if `post_install_module` is set to `true`"
   default     = ""
 }
 


### PR DESCRIPTION
Following ovh/terraform-ovh-publiccloud-cfssl@89d51c2c374f34c60222989c6af66d5d7ee3597f , all references to `ssh_*_private_key` have been removed. 

**Warning!:** not tested.